### PR TITLE
Make sure the locking mechanism matches LOCK_ASSERT

### DIFF
--- a/include/convergent_matrix_mpi.hpp
+++ b/include/convergent_matrix_mpi.hpp
@@ -287,6 +287,12 @@ namespace cm {
       assert( MPI_Initialized( &mpi_init ) == MPI_SUCCESS );
       assert( mpi_init );
 
+      // make sure the locking mechanism matches LOCK_ASSERT (i.e. we are using
+      // shared-mode locks throughout if LOCK_ASSERT is MPI_MODE_NOCHECK)
+#if ! ( defined(USE_MPI_LOCK_SHARED) || defined(USE_MPI_LOCK_ALL) )
+      assert( LOCK_ASSERT == 0 );
+#endif // ! ( defined(USE_MPI_LOCK_SHARED) || defined(USE_MPI_LOCK_ALL) )
+
       // get process pool config
       MPI_Comm_rank( MPI_COMM_WORLD, &_mpi_rank );
       MPI_Comm_size( MPI_COMM_WORLD, &_mpi_size );


### PR DESCRIPTION
Not at all major, just catches a slight inconsistency in the default behavior. From the commit:

If we are not using shared-mode locks throughout, either explicitly with
`USE_MPI_LOCK_SHARED` or implicitly by `USE_MPI_LOCK_ALL`, then `LOCK_ASSERT`
must not be `MPI_MODE_NOCHECK`.